### PR TITLE
Fix missing whisper_transcriber and crawler bug

### DIFF
--- a/spiritMythos/scraper.py
+++ b/spiritMythos/scraper.py
@@ -29,6 +29,7 @@ def crawl(url):
     print(f"Crawling: {url}")
     try:
         ext = os.path.splitext(url)[1].lower()
+        soup = None
         if ext == ".pdf":
             print(f"  Downloading and extracting PDF: {url}")
             text = extract_pdf_text(url)
@@ -49,17 +50,18 @@ def crawl(url):
             print(f"  Saving text from: {url}")
             with open(OUTPUT_FILE, "a", encoding="utf-8") as f:
                 f.write(f"URL: {url}\n{text}\n\n")
-        # Find and crawl relevant links
-        for link in soup.find_all("a", href=True):
-            next_url = urljoin(url, link["href"])
-            parsed = urlparse(next_url)
-            if parsed.scheme not in ("http", "https"):
-                continue
-            if is_relevant_link(next_url, BASE_URL):
-                if next_url not in VISITED:
-                    ALL_LINKS.add(next_url)
-                    print(f"    Found internal link: {next_url}")
-                    crawl(next_url)
+        # Find and crawl relevant links only if soup exists
+        if soup is not None:
+            for link in soup.find_all("a", href=True):
+                next_url = urljoin(url, link["href"])
+                parsed = urlparse(next_url)
+                if parsed.scheme not in ("http", "https"):
+                    continue
+                if is_relevant_link(next_url, BASE_URL):
+                    if next_url not in VISITED:
+                        ALL_LINKS.add(next_url)
+                        print(f"    Found internal link: {next_url}")
+                        crawl(next_url)
         time.sleep(1)  # Be polite to the server
     except Exception as e:
         print(f"Error crawling {url}: {e}")

--- a/spiritMythos/whisper_transcriber.py
+++ b/spiritMythos/whisper_transcriber.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+import requests
+import whisper
+
+
+def download_audio(url: str) -> str:
+    """Download an audio or video file and return a temporary file path."""
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    ext = os.path.splitext(url)[1] or ".mp3"
+    fd, path = tempfile.mkstemp(suffix=ext)
+    with os.fdopen(fd, "wb") as tmp:
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                tmp.write(chunk)
+    return path
+
+
+def transcribe_audio(url: str) -> str:
+    """Download media from ``url`` and return the Whisper transcription."""
+    audio_path = download_audio(url)
+    try:
+        model = whisper.load_model("base")
+        result = model.transcribe(audio_path)
+        text = result.get("text", "").strip()
+    except Exception:
+        text = ""
+    finally:
+        os.remove(audio_path)
+    return text


### PR DESCRIPTION
## Summary
- add a `whisper_transcriber` helper for audio transcription
- guard scraper link crawling when parsing non-html content

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68409fd72b908333ad3288404cda48bc